### PR TITLE
Fix attribute hash generation

### DIFF
--- a/src/Models/Traits/AtomicDatabaseActions.php
+++ b/src/Models/Traits/AtomicDatabaseActions.php
@@ -42,6 +42,8 @@ trait AtomicDatabaseActions
 
     protected static function getAtomicCacheKey(array $attributes) : string
     {
-        return get_called_class() . ':' . md5(serialize(sort($attributes)));
+        sort($attributes);
+
+        return get_called_class() . ':' . md5(serialize($attributes));
     }
 }


### PR DESCRIPTION
## Description

Fixed issue where sort returns a bool and that was used for serialization, not the actual attributes, causing all calls to use the same cache key

## Release Notes

_Suggested details for the release notes to explain how this impacts users_

## Types of changes

- [X] Bugfix
- [ ] New feature
- [ ] Chore (mundane code change)
- [ ] Maintenance (clean up)

## Checklist

- [ ] Unit tests pass locally
- [ ] Added tests to code that was updated or edited
- [ ] Updated/added documentation
