### PR TITLE
Revert Laravel 9 package updates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.0]
-        laravel: [9.*]
+        laravel: [8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
+          - laravel: 8.*
             testbench: ^7.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
-            testbench: ^7.0
+            testbench: ^6.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^8.37",
         "jdorn/sql-formatter": "^1.2",
         "league/flysystem-aws-s3-v3": ">=1.0",
         "slickdeals/statsd": "~3.0",
         "spatie/laravel-package-tools": "^1.4.3"
     },
     "require-dev": {
-        "nunomaduro/collision": "^6.0",
-        "orchestra/testbench": "^7.0",
+        "nunomaduro/collision": "^5.3",
+        "orchestra/testbench": "^6.15",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
         "vimeo/psalm": "^4.4"


### PR DESCRIPTION
## Description

The primary users of this package are currently on Laravel 8 and some
updates for those and other packages are needed. Until those are
upgraded to 9 this should stay at 8 with them

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Chore (mundane code change)
- [ ] Maintenance (clean up)

## Checklist

- [ ] Unit tests pass locally
- [ ] Added tests to code that was updated or edited
- [ ] Updated/added documentation
